### PR TITLE
Add DOM capture for test step results

### DIFF
--- a/cua-server/src/agents/test-script-review-agent.ts
+++ b/cua-server/src/agents/test-script-review-agent.ts
@@ -17,11 +17,13 @@ interface TestScriptState {
     status: string;
     step_reasoning: string;
     image_path?: string;
+    domContent?: string;
   }>;
 }
 
 interface Task {
   base64Image: string;
+  domContent?: string;
   userInstruction?: string;
   resolve: (value: any) => void;
   reject: (error: any) => void;
@@ -144,11 +146,18 @@ class TestScriptReviewAgent {
    */
   async checkTestScriptStatus(
     base64Image: string,
+    domContent?: string,
     userInstruction?: string
   ): Promise<any> {
     return new Promise((resolve, reject) => {
       // Enqueue the new task.
-      this.taskQueue.push({ base64Image, userInstruction, resolve, reject });
+      this.taskQueue.push({
+        base64Image,
+        domContent,
+        userInstruction,
+        resolve,
+        reject,
+      });
       this.processQueue();
     });
   }
@@ -161,11 +170,12 @@ class TestScriptReviewAgent {
     this.processingQueue = true;
 
     while (this.taskQueue.length > 0) {
-      const { base64Image, userInstruction, resolve, reject } =
+      const { base64Image, domContent, userInstruction, resolve, reject } =
         this.taskQueue.shift()!;
       try {
         const result = await this.processTestScriptStatus(
           base64Image,
+          domContent,
           userInstruction
         );
         resolve(result);
@@ -182,6 +192,7 @@ class TestScriptReviewAgent {
    */
   private async processTestScriptStatus(
     base64Image: string,
+    domContent?: string,
     userInstruction?: string
   ): Promise<any> {
     logger.debug(
@@ -312,7 +323,7 @@ class TestScriptReviewAgent {
         logger.error("Error saving screenshot", err);
       }
 
-      // Iterate through steps and attach the screenshot path only for those with a status change.
+      // Iterate through steps and attach the screenshot path and DOM only for those with a status change.
       for (const newStep of newState.steps) {
         const oldStep = oldSteps.find(
           (s) => s.step_number === newStep.step_number
@@ -324,8 +335,14 @@ class TestScriptReviewAgent {
           ) {
             newStep.image_path =
               "/test_results/" + this.runFolder + "/" + screenshotFilename;
+            if (domContent) {
+              newStep.domContent = domContent;
+            }
           } else if (oldStep.image_path) {
             newStep.image_path = oldStep.image_path;
+            if (oldStep.domContent) {
+              newStep.domContent = oldStep.domContent;
+            }
           }
         }
       }
@@ -335,8 +352,13 @@ class TestScriptReviewAgent {
         const oldStep = oldSteps.find(
           (s) => s.step_number === newStep.step_number
         );
-        if (oldStep && oldStep.image_path) {
-          newStep.image_path = oldStep.image_path;
+        if (oldStep) {
+          if (oldStep.image_path) {
+            newStep.image_path = oldStep.image_path;
+          }
+          if (oldStep.domContent) {
+            newStep.domContent = oldStep.domContent;
+          }
         }
       }
     }

--- a/cua-server/src/handlers/cua-loop-handler.ts
+++ b/cua-server/src/handlers/cua-loop-handler.ts
@@ -55,10 +55,15 @@ export async function cuaLoopHandler(
     const screenshot_before_login = await page.screenshot();
     const screenshot_before_login_base64 =
       screenshot_before_login.toString("base64");
+    const dom_before_login = await page.evaluate(
+      () => document.documentElement.outerHTML
+    );
 
     // Asynchronously check the status of the test script.
-    const testScriptReviewResponsePromise =
-      testCaseReviewAgent.checkTestScriptStatus(screenshot_before_login_base64);
+    const testScriptReviewResponsePromise = testCaseReviewAgent.checkTestScriptStatus(
+      screenshot_before_login_base64,
+      dom_before_login
+    );
 
     // Asynchronously emit the test script review response to the socket.
     testScriptReviewResponsePromise.then((testScriptReviewResponse) => {
@@ -98,11 +103,15 @@ export async function cuaLoopHandler(
       const screenshot_after_login = await page.screenshot();
       const screenshot_after_login_base64 =
         screenshot_after_login.toString("base64");
+      const dom_after_login = await page.evaluate(
+        () => document.documentElement.outerHTML
+      );
 
       // Asynchronously check the status of the test script.
       const testScriptReviewResponsePromise_after_login =
         testCaseReviewAgent.checkTestScriptStatus(
-          screenshot_after_login_base64
+          screenshot_after_login_base64,
+          dom_after_login
         );
 
       // Asynchronously emit the test script review response to the socket.

--- a/cua-server/src/lib/computer-use-loop.ts
+++ b/cua-server/src/lib/computer-use-loop.ts
@@ -155,9 +155,15 @@ export async function computerUseLoop(
       if (["click"].includes(action?.type)) {
         const screenshotBuffer = await page.screenshot();
         const screenshotBase64 = screenshotBuffer.toString("base64");
+        const domContent = await page.evaluate(
+          () => document.documentElement.outerHTML
+        );
 
         const testScriptReviewResponsePromise =
-          testCaseReviewAgent.checkTestScriptStatus(screenshotBase64);
+          testCaseReviewAgent.checkTestScriptStatus(
+            screenshotBase64,
+            domContent
+          );
         // Asynchronously emit the test script review response to the socket.
         testScriptReviewResponsePromise
           .then((testScriptReviewResponse) => {


### PR DESCRIPTION
## Summary
- include DOM content per step in `TestScriptReviewAgent`
- send DOM snapshots from `cua-loop-handler` and `computer-use-loop`

## Testing
- `npm run lint --workspace frontend` *(fails: `next lint` errors)*
- `npm run lint --workspace sample-test-app`

------
https://chatgpt.com/codex/tasks/task_e_688ceb6d40b083329000d31670c7682f