### PR TITLE
refactor: remove login handling from CUA

### DIFF
--- a/cua-server/src/handlers/cua-loop-handler.ts
+++ b/cua-server/src/handlers/cua-loop-handler.ts
@@ -1,13 +1,11 @@
 // lib/handlers/playwright-loop-handler.ts
-import playwright, { Page } from "playwright";
+import playwright from "playwright";
 const { chromium } = playwright;
 import logger from "../utils/logger";
 import { computerUseLoop } from "../lib/computer-use-loop";
 import { Socket } from "socket.io";
 import TestScriptReviewAgent from "../agents/test-script-review-agent";
 import { setupCUAModel } from "../services/openai-cua-client";
-import { LoginService } from "../services/login-service";
-import { ModelInput } from "../services/openai-cua-client";
 
 // Read viewport dimensions from .env file with defaults if not set
 const displayWidth: number = parseInt(process.env.DISPLAY_WIDTH || "1024", 10);
@@ -17,11 +15,7 @@ export async function cuaLoopHandler(
   systemPrompt: string,
   url: string,
   socket: Socket,
-  testCaseReviewAgent: TestScriptReviewAgent,
-  username: string,
-  password: string,
-  loginRequired: boolean,
-  userInfo?: string
+  testCaseReviewAgent: TestScriptReviewAgent
 ) {
   logger.info("Starting test script execution...");
   socket.emit("message", "Starting test script execution...");
@@ -52,18 +46,17 @@ export async function cuaLoopHandler(
     await page.waitForTimeout(2000);
 
     // Capture an initial screenshot.
-    const screenshot_before_login = await page.screenshot();
-    const screenshot_before_login_base64 =
-      screenshot_before_login.toString("base64");
+    const initialScreenshot = await page.screenshot();
+    const initialScreenshotBase64 = initialScreenshot.toString("base64");
 
     // Asynchronously check the status of the test script.
     const testScriptReviewResponsePromise =
-      testCaseReviewAgent.checkTestScriptStatus(screenshot_before_login_base64);
+      testCaseReviewAgent.checkTestScriptStatus(initialScreenshotBase64);
 
     // Asynchronously emit the test script review response to the socket.
     testScriptReviewResponsePromise.then((testScriptReviewResponse) => {
       logger.debug(
-        "Sending screenshot before login to Test Script Review Agent"
+        "Sending initial screenshot to Test Script Review Agent"
       );
       socket.emit("testscriptupdate", testScriptReviewResponse);
       logger.trace(
@@ -78,75 +71,8 @@ export async function cuaLoopHandler(
     // Await till network is idle.
     await page.waitForTimeout(2000);
 
-    let modelInput: ModelInput;
-
-    if (loginRequired) {
-      // Note to the developer: Different applications will need their own login handlers.
-      logger.debug("Login required... proceeding with login.");
-      socket.emit("message", "Login required... proceeding with login.");
-
-      const loginService = new LoginService();
-      await loginService.fillin_login_credentials(username, password, page);
-
-      logger.trace(
-        "Login execution completed... proceeding with test script execution."
-      );
-
-      // wait for 5 seconds
-      await page.waitForTimeout(5000);
-
-      const screenshot_after_login = await page.screenshot();
-      const screenshot_after_login_base64 =
-        screenshot_after_login.toString("base64");
-
-      // Asynchronously check the status of the test script.
-      const testScriptReviewResponsePromise_after_login =
-        testCaseReviewAgent.checkTestScriptStatus(
-          screenshot_after_login_base64
-        );
-
-      // Asynchronously emit the test script review response to the socket.
-      testScriptReviewResponsePromise_after_login.then(
-        (testScriptReviewResponse) => {
-          logger.debug(
-            "Sending screenshot after login to Test Script Review Agent"
-          );
-          // Emit the test script review response to the socket.
-          socket.emit("testscriptupdate", testScriptReviewResponse);
-          logger.trace(
-            `Test script state emitted after login: ${JSON.stringify(
-              testScriptReviewResponse,
-              null,
-              2
-            )}`
-          );
-        }
-      );
-
-      await loginService.click_login_button(page);
-
-      socket.emit(
-        "message",
-        "Login step executed... proceeding with test script execution."
-      );
-
-      modelInput = {
-        screenshotBase64: screenshot_after_login_base64,
-        previousResponseId: undefined,
-        lastCallId: undefined,
-      };
-    } else {
-      // If login is not required, use the screenshot before login.
-      modelInput = {
-        screenshotBase64: screenshot_before_login_base64,
-        previousResponseId: undefined,
-        lastCallId: undefined,
-      };
-    }
-
     // Start with an initial call (without a screenshot or call_id)
-    const userInfoStr = userInfo ?? "";
-    let initial_response = await setupCUAModel(systemPrompt, userInfoStr);
+    let initial_response = await setupCUAModel(systemPrompt, "");
 
     logger.debug(
       `Initial response from CUA model: ${JSON.stringify(

--- a/cua-server/src/handlers/test-case-initiation-handler.ts
+++ b/cua-server/src/handlers/test-case-initiation-handler.ts
@@ -11,15 +11,11 @@ export async function handleTestCaseInitiated(
 ): Promise<void> {
   logger.debug(`Received testCaseInitiated with data: ${JSON.stringify(data)}`);
   try {
-    const { testCase, url, userName, password, userInfo } = data as {
+    const { testCase, url } = data as {
       testCase: string;
       url: string;
-      userName: string;
-      password: string;
-      userInfo: string;
-      loginRequired?: boolean;
     };
-    const loginRequired = data.loginRequired ?? true;
+    const loginRequired = false;
 
     logger.debug(`Login required: ${loginRequired}`);
 
@@ -29,7 +25,7 @@ export async function handleTestCaseInitiated(
     );
 
     // Create system prompt by combining form inputs.
-    const msg = `${testCase} URL: ${url} User Name: ${userName} Password: *********\n USER INFO:\n${userInfo}`;
+    const msg = `${testCase} URL: ${url}`;
 
     const testCaseAgent = new TestCaseAgent(loginRequired);
 
@@ -70,16 +66,7 @@ export async function handleTestCaseInitiated(
 
     // Start the test execution using the provided URL.
     // Pass the test case review agent to the cuaLoopHandler.
-    await cuaLoopHandler(
-      testScript,
-      url,
-      socket,
-      testCaseReviewAgent,
-      userName,
-      password,
-      loginRequired,
-      userInfo
-    );
+    await cuaLoopHandler(testScript, url, socket, testCaseReviewAgent);
   } catch (error) {
     logger.error(`Error in handleTestCaseInitiated: ${error}`);
     socket.emit("message", "Error initiating test case.");


### PR DESCRIPTION
## Summary
- drop username/password parameters from CUA loop
- simplify test case initiation to handle only testCase and url
- always start CUA model without user info or login flow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm -w cua-server run build` *(fails: Cannot find module type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b3300d5c83329d72b74f82a85be8