### PR TITLE
chore: remove user credentials constants

### DIFF
--- a/frontend/components/ConfigPanel.tsx
+++ b/frontend/components/ConfigPanel.tsx
@@ -30,13 +30,7 @@ import { Switch } from "@/components/ui/switch";
 
 import { emitTestCaseInitiated } from "@/components/SocketIOManager";
 import AppHeader from "@/components/AppHeader";
-import {
-  PASSWORD,
-  TEST_APP_URL,
-  TEST_CASE,
-  USER_INFO,
-  USERNAME,
-} from "@/lib/constants";
+import { TEST_APP_URL, TEST_CASE } from "@/lib/constants";
 
 interface ConfigPanelProps {
   onSubmitted?: (testCase: string) => void;
@@ -45,11 +39,11 @@ interface ConfigPanelProps {
 export default function ConfigPanel({ onSubmitted }: ConfigPanelProps) {
   const [testCase, setTestCase] = useState(TEST_CASE);
   const [url, setUrl] = useState(TEST_APP_URL);
-  const [username, setUsername] = useState(USERNAME);
-  const [password, setPassword] = useState(PASSWORD);
-  const [name, setName] = useState(USER_INFO.name);
-  const [email, setEmail] = useState(USER_INFO.email);
-  const [address, setAddress] = useState(USER_INFO.address);
+  const [username, setUsername] = useState("test_user_name");
+  const [password, setPassword] = useState("test_password");
+  const [name, setName] = useState("Cua Blossom");
+  const [email, setEmail] = useState("cua@example.com");
+  const [address, setAddress] = useState("123 Main St, Anytown, USA");
   const [requiresLogin, setRequiresLogin] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [formSubmitted, setFormSubmitted] = useState(false);

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -6,11 +6,3 @@ As long as you haven't found these items, continue to the next page if there is 
 Once you have added these items to the cart, go to the cart (click on the cart icon on the right of the top navbar, scroll up if you don't see it), enter shipping details with the user info and checkout.`;
 
 export const TEST_APP_URL = "http://localhost:3005";
-export const USERNAME = "test_user_name";
-export const PASSWORD = "test_password";
-
-export const USER_INFO = {
-  name: "Cua Blossom",
-  email: "cua@example.com",
-  address: "123 Main St, Anytown, USA",
-};


### PR DESCRIPTION
## Summary
- remove USERNAME, PASSWORD, and USER_INFO from constants
- inline default credential values in ConfigPanel

## Testing
- `npm test --prefix frontend` (fails: Missing script "test")
- `npm run lint --prefix frontend` (fails: 'React' is defined but never used)


------
https://chatgpt.com/codex/tasks/task_e_68a0b32f60c48332a4f6c2a454332ab3