### PR TITLE
feat: simplify testing UI

### DIFF
--- a/cua-server/src/lib/computer-use-loop.ts
+++ b/cua-server/src/lib/computer-use-loop.ts
@@ -6,6 +6,7 @@ import {
 } from "../services/openai-cua-client";
 import { handleModelAction } from "../handlers/action-handler";
 import logger from "../utils/logger";
+import { scrollPageAndCapture, validateHeadings } from "../utils/pageUtils";
 import { Socket } from "socket.io";
 import TestScriptReviewAgent from "../agents/test-script-review-agent";
 
@@ -21,6 +22,8 @@ export async function computerUseLoop(
   switchedToNewTab: boolean = false // <-- Flag to ensure recursion happens only once for a new tab.
 ) {
   await page.screenshot({ path: "screenshot.png" });
+  await scrollPageAndCapture(page);
+  await validateHeadings(page);
   while (true) {
     // Check if the test case status is 'fail'.
     if (socket.data.testCaseStatus === "fail") {

--- a/cua-server/src/lib/constants.ts
+++ b/cua-server/src/lib/constants.ts
@@ -2,25 +2,21 @@ export const PROMPT_WITH_LOGIN = `
    You are a test case authoring agent. You will be given instructions by user on what they want to test.
    Create test steps Step 1, Step 2, … Return in JSON format { step_number: step_instructions: status: }
    Provide all the steps in your response.
-   
-   The first 3 steps are always:
+
+   The first step is always:
    1. Open the browser and navigate to the login URL.
-   2. Enter username and password.
-   3. Click *Log In* and verify successful sign‑in.
-   
+
    Then add the actual test steps the user asked for.
-   
+
    SAMPLE RESPONSE:
    {
      "steps": [
        { "step_number": 1, "step_instructions": "Open a web browser and navigate to the login URL: <login URL>",            "status": "pending" },
-       { "step_number": 2, "step_instructions": "Enter the username '<username>' and password '********'.",                "status": "pending" },
-       { "step_number": 3, "step_instructions": "Click the 'Log In' button and verify successful sign‑in.",                "status": "pending" },
-       { "step_number": 4, "step_instructions": "From the home page, click the 'Accounts' tab.",                           "status": "pending" },
-       { "step_number": 5, "step_instructions": "Click 'New' to create a new account.",                                    "status": "pending" },
-       { "step_number": 6, "step_instructions": "Fill the form with mock data (e.g., Account Name 'Test Account').",       "status": "pending" },
-       { "step_number": 7, "step_instructions": "Click 'Save' and confirm the account appears in the list.",               "status": "pending" },
-       { "step_number": 8, "step_instructions": "Take a screenshot to confirm the account was created.",                   "status": "pending" }
+       { "step_number": 2, "step_instructions": "From the home page, click the 'Accounts' tab.",                           "status": "pending" },
+       { "step_number": 3, "step_instructions": "Click 'New' to create a new account.",                                    "status": "pending" },
+       { "step_number": 4, "step_instructions": "Fill the form with mock data (e.g., Account Name 'Test Account').",       "status": "pending" },
+       { "step_number": 5, "step_instructions": "Click 'Save' and confirm the account appears in the list.",               "status": "pending" },
+       { "step_number": 6, "step_instructions": "Take a screenshot to confirm the account was created.",                   "status": "pending" }
      ]
    }
    `;
@@ -29,12 +25,12 @@ export const PROMPT_WITHOUT_LOGIN = `
    You are a test case authoring agent. You will be given instructions by user on what they want to test.
    Create test steps Step 1, Step 2, … Return in JSON format { step_number: step_instructions: status: }
    Provide all the steps in your response.
-   
+
    The first step is always:
    1. Open the browser and navigate to the target URL.
-   
-   Then add the actual test steps the user asked for. Do not include any login steps. This site does not require login. 
-   
+
+   Then add the actual test steps the user asked for. Do not include any login steps. This site does not require login.
+
    SAMPLE RESPONSE:
    {
      "steps": [
@@ -49,7 +45,7 @@ export const PROMPT_WITHOUT_LOGIN = `
    `;
 
 export const TEST_SCRIPT_REVIEW_PROMPT = `
-  You are a test script review agent. You will be given a set of test cases in the format below and screenshots of the test results. 
+  You are a test script review agent. You will be given a set of test cases in the format below and screenshots of the test results.
 
   SAMPLE FORMAT:
   {
@@ -79,6 +75,6 @@ export const TEST_SCRIPT_REVIEW_PROMPT = `
     ]
   }
 
-  Do not add or remove any steps. Do not modify any step that already has a "Pass" status or "Fail" status unless you are certain it is now changed. Keep 'pending' steps as needed. 
+  Do not add or remove any steps. Do not modify any step that already has a "Pass" status or "Fail" status unless you are certain it is now changed. Keep 'pending' steps as needed.
   Keep the same step_number order.
 `;

--- a/cua-server/src/utils/pageUtils.ts
+++ b/cua-server/src/utils/pageUtils.ts
@@ -1,0 +1,38 @@
+import { Page } from "playwright";
+import logger from "./logger";
+
+/**
+ * Scrolls the page by one viewport height at a time and captures a screenshot
+ * after each scroll. Screenshots are saved as `scroll-<index>.png` in the
+ * working directory.
+ */
+export async function scrollPageAndCapture(page: Page): Promise<void> {
+  const height = page.viewportSize()?.height ?? 768;
+  let scrolled = 0;
+  let index = 0;
+  const totalHeight = await page.evaluate(() => document.body.scrollHeight);
+
+  while (scrolled < totalHeight) {
+    await page.evaluate((h) => window.scrollBy(0, h), height);
+    await page.waitForTimeout(500);
+    scrolled += height;
+    index += 1;
+    const path = `scroll-${index}.png`;
+    await page.screenshot({ path });
+    logger.debug(`Captured screenshot: ${path}`);
+  }
+}
+
+/**
+ * Checks for the presence of heading elements on the page.
+ */
+export async function validateHeadings(page: Page): Promise<{ h1: boolean; h2: boolean; h3: boolean }> {
+  const [h1, h2, h3] = await Promise.all([
+    page.locator("h1").count(),
+    page.locator("h2").count(),
+    page.locator("h3").count(),
+  ]);
+  const result = { h1: h1 > 0, h2: h2 > 0, h3: h3 > 0 };
+  logger.debug(`Heading validation: ${JSON.stringify(result)}`);
+  return result;
+}

--- a/frontend/components/ConfigPanel.tsx
+++ b/frontend/components/ConfigPanel.tsx
@@ -2,16 +2,7 @@
 "use client";
 
 import React, { useState } from "react";
-import {
-  Code,
-  ExternalLink,
-  Home,
-  Lock,
-  Mail,
-  Send,
-  User,
-  Variable,
-} from "lucide-react";
+import { ExternalLink, Send } from "lucide-react";
 import {
   Card,
   CardContent,
@@ -22,21 +13,12 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
-import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
-import { Switch } from "@/components/ui/switch";
 
 import { emitTestCaseInitiated } from "@/components/SocketIOManager";
 import AppHeader from "@/components/AppHeader";
-import {
-  PASSWORD,
-  TEST_APP_URL,
-  TEST_CASE,
-  USER_INFO,
-  USERNAME,
-} from "@/lib/constants";
+import { TEST_APP_URL, TEST_CASE } from "@/lib/constants";
 
 interface ConfigPanelProps {
   onSubmitted?: (testCase: string) => void;
@@ -45,17 +27,8 @@ interface ConfigPanelProps {
 export default function ConfigPanel({ onSubmitted }: ConfigPanelProps) {
   const [testCase, setTestCase] = useState(TEST_CASE);
   const [url, setUrl] = useState(TEST_APP_URL);
-  const [username, setUsername] = useState(USERNAME);
-  const [password, setPassword] = useState(PASSWORD);
-  const [name, setName] = useState(USER_INFO.name);
-  const [email, setEmail] = useState(USER_INFO.email);
-  const [address, setAddress] = useState(USER_INFO.address);
-  const [requiresLogin, setRequiresLogin] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [formSubmitted, setFormSubmitted] = useState(false);
-  const [tabValue, setTabValue] = useState<"test-case" | "variables">(
-    "test-case"
-  );
 
   // Submit handler
   const handleSubmit = (e: React.FormEvent) => {
@@ -68,14 +41,6 @@ export default function ConfigPanel({ onSubmitted }: ConfigPanelProps) {
     emitTestCaseInitiated({
       testCase,
       url,
-      userName: username,
-      password,
-      loginRequired: requiresLogin,
-      userInfo: JSON.stringify({
-        name,
-        email,
-        address,
-      }),
     });
 
     onSubmitted?.(testCase);
@@ -110,242 +75,63 @@ export default function ConfigPanel({ onSubmitted }: ConfigPanelProps) {
       <div className="w-full">
         <AppHeader />
 
-        {/* Tabs */}
-        <Tabs
-          value={tabValue}
-          onValueChange={(value) =>
-            setTabValue(value as "test-case" | "variables")
-          }
-          className="w-full"
-        >
-          <TabsList className="grid grid-cols-2 w-full mb-6">
-            <TabsTrigger
-              value="test-case"
-              className="flex items-center gap-2 py-1"
-            >
-              <Code className="h-4 w-4" />
-              Test Case
-            </TabsTrigger>
-            <TabsTrigger value="variables" className="flex items-center gap-2">
-              <Variable className="h-4 w-4" />
-              Variables
-            </TabsTrigger>
-          </TabsList>
+        <form onSubmit={handleSubmit}>
+          <Card>
+            <CardHeader>
+              <CardTitle>Test case definition</CardTitle>
+              <CardDescription>
+                Provide the target application link and testing instructions.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="flex items-center gap-3">
+                <Label
+                  htmlFor="url"
+                  className="flex items-center gap-2 whitespace-nowrap w-24"
+                >
+                  <ExternalLink className="h-4 w-4 text-muted-foreground" />
+                  URL
+                </Label>
+                <Input
+                  id="url"
+                  type="url"
+                  placeholder="http://localhost:3001"
+                  value={url}
+                  onChange={(e) => setUrl(e.target.value)}
+                  disabled={submitting}
+                  className="flex-1"
+                />
+              </div>
 
-          {/* Test-case tab */}
-          <TabsContent value="test-case">
-            <Card>
-              <CardHeader>
-                <CardTitle>Test case definition</CardTitle>
-                <CardDescription>
-                  Describe what the frontend testing agent should do to test
-                  your application in natural language.
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
+              <div className="space-y-2">
                 <Label htmlFor="test-case">Test instructions</Label>
                 <Textarea
                   id="test-case"
-                  className="min-h-[200px] resize-y mt-2"
+                  className="min-h-[200px] resize-y"
                   value={testCase}
                   onChange={(e) => setTestCase(e.target.value)}
                   disabled={submitting}
                 />
-              </CardContent>
-              <CardFooter className="flex justify-between">
-                <Button
-                  variant="outline"
-                  onClick={() => setTestCase("")}
-                  disabled={submitting}
-                >
-                  Clear
-                </Button>
-                <Button
-                  type="button"
-                  onClick={() => setTabValue("variables")}
-                  disabled={submitting}
-                >
-                  Next: Configure Variables
-                </Button>
-              </CardFooter>
-            </Card>
-          </TabsContent>
-
-          {/* Variables tab */}
-          <TabsContent value="variables">
-            <form onSubmit={handleSubmit}>
-              <Card>
-                <CardHeader>
-                  <CardTitle>Configure Test Variables</CardTitle>
-                  <CardDescription>
-                    Provide the environment details and credentials (if
-                    required).
-                  </CardDescription>
-                </CardHeader>
-
-                <CardContent className="space-y-6 max-h-[42vh] overflow-y-auto">
-                  {/* URL */}
-                  <div className="flex items-center gap-3">
-                    <Label
-                      htmlFor="url"
-                      className="flex items-center gap-2 whitespace-nowrap w-24"
-                    >
-                      <ExternalLink className="h-4 w-4 text-muted-foreground" />
-                      URL
-                    </Label>
-                    <Input
-                      id="url"
-                      type="url"
-                      placeholder="http://localhost:3001"
-                      value={url}
-                      onChange={(e) => setUrl(e.target.value)}
-                      disabled={submitting}
-                      className="flex-1"
-                    />
-                  </div>
-
-                  <Separator />
-
-                  {/* Credentials */}
-                  <div className="space-y-4">
-                    <div className="flex gap-6 items-center">
-                      {/* Login toggle */}
-                      <div className="flex items-center gap-3">
-                        <Switch
-                          id="requires-login"
-                          checked={requiresLogin}
-                          onCheckedChange={setRequiresLogin}
-                          disabled={submitting}
-                        />
-                        <Label htmlFor="requires-login">Login</Label>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Label
-                          htmlFor="username"
-                          className="flex items-center gap-2 whitespace-nowrap w-24"
-                        >
-                          <User className="h-4 w-4 text-muted-foreground" />
-                          Username
-                        </Label>
-                        <Input
-                          id="username"
-                          type="text"
-                          autoComplete="username"
-                          placeholder="admin"
-                          value={username}
-                          onChange={(e) => setUsername(e.target.value)}
-                          disabled={submitting || !requiresLogin}
-                          className="flex-1"
-                        />
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Label
-                          htmlFor="password"
-                          className="flex items-center gap-2 whitespace-nowrap w-24"
-                        >
-                          <Lock className="h-4 w-4 text-muted-foreground" />
-                          Password
-                        </Label>
-                        <Input
-                          id="password"
-                          type="password"
-                          placeholder="••••••••••"
-                          value={password}
-                          onChange={(e) => setPassword(e.target.value)}
-                          disabled={submitting || !requiresLogin}
-                          className="flex-1"
-                        />
-                      </div>
-                    </div>
-
-                    <Separator />
-
-                    {/* User info */}
-
-                    <div className="space-y-3">
-                      <Label htmlFor="requires-login">User info</Label>
-
-                      <div className="flex gap-6 items-center">
-                        <div className="flex items-center gap-2">
-                          <Label
-                            htmlFor="name"
-                            className="flex items-center gap-2 whitespace-nowrap w-24"
-                          >
-                            <User className="h-4 w-4 text-muted-foreground" />
-                            Name
-                          </Label>
-                          <Input
-                            id="name"
-                            type="text"
-                            autoComplete="name"
-                            placeholder="John Doe"
-                            value={name}
-                            onChange={(e) => setName(e.target.value)}
-                            className="flex-1"
-                          />
-                        </div>
-                        <div className="flex flex-1 items-center gap-2">
-                          <Label
-                            htmlFor="email"
-                            className="flex items-center gap-2 whitespace-nowrap w-24"
-                          >
-                            <Mail className="h-4 w-4 text-muted-foreground" />
-                            Email
-                          </Label>
-                          <Input
-                            id="email"
-                            type="email"
-                            autoComplete="email"
-                            placeholder="john.doe@example.com"
-                            value={email}
-                            onChange={(e) => setEmail(e.target.value)}
-                            className="flex-1"
-                          />
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Label
-                          htmlFor="address"
-                          className="flex items-center gap-2 whitespace-nowrap w-24"
-                        >
-                          <Home className="h-4 w-4 text-muted-foreground" />
-                          Address
-                        </Label>
-                        <Input
-                          id="address"
-                          type="text"
-                          autoComplete="address"
-                          placeholder="123 Main St, Anytown, USA"
-                          value={address}
-                          onChange={(e) => setAddress(e.target.value)}
-                          disabled={submitting || !requiresLogin}
-                          className="flex-1"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                </CardContent>
-
-                <CardFooter className="flex justify-between">
-                  <Button
-                    variant="outline"
-                    type="button"
-                    onClick={() => setTabValue("test-case")}
-                    disabled={submitting}
-                  >
-                    Back
-                  </Button>
-
-                  <Button type="submit" className="gap-2" disabled={submitting}>
-                    <Send className="h-4 w-4" />
-                    {submitting ? "Submitting…" : "Submit"}
-                  </Button>
-                </CardFooter>
-              </Card>
-            </form>
-          </TabsContent>
-        </Tabs>
+              </div>
+            </CardContent>
+            <CardFooter className="flex justify-between">
+              <Button
+                variant="outline"
+                type="button"
+                onClick={() => setTestCase("")}
+                disabled={submitting}
+              >
+                Clear
+              </Button>
+              <Button type="submit" className="gap-2" disabled={submitting}>
+                <Send className="h-4 w-4" />
+                {submitting ? "Submitting…" : "Submit"}
+              </Button>
+            </CardFooter>
+          </Card>
+        </form>
       </div>
     </div>
   );
 }
+

--- a/frontend/components/SocketIOManager.tsx
+++ b/frontend/components/SocketIOManager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import io, { Socket } from "socket.io-client";
 
 import useConversationStore from "@/stores/useConversationStore";


### PR DESCRIPTION
## Summary
- remove login-specific default steps from test case prompt
- scroll new pages and capture screenshots while checking heading tags

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint --prefix frontend`
- `npm run build --prefix cua-server`


------
https://chatgpt.com/codex/tasks/task_e_68a0ccc0274083328e3ddb45b26bab9c