### PR TITLE
Add test item dialog for link and content validation

### DIFF
--- a/frontend/components/ConfigPanel.tsx
+++ b/frontend/components/ConfigPanel.tsx
@@ -19,6 +19,8 @@ import { Button } from "@/components/ui/button";
 import { emitTestCaseInitiated } from "@/components/SocketIOManager";
 import AppHeader from "@/components/AppHeader";
 import { TEST_APP_URL, TEST_CASE } from "@/lib/constants";
+import TestItemDialog from "@/components/TestItemDialog";
+import { TestItem } from "@/types/testItem";
 
 interface ConfigPanelProps {
   onSubmitted?: (testCase: string) => void;
@@ -29,6 +31,12 @@ export default function ConfigPanel({ onSubmitted }: ConfigPanelProps) {
   const [url, setUrl] = useState(TEST_APP_URL);
   const [submitting, setSubmitting] = useState(false);
   const [formSubmitted, setFormSubmitted] = useState(false);
+  const [testItems, setTestItems] = useState<TestItem[]>([]);
+  const [showDialog, setShowDialog] = useState(false);
+
+  const handleAddItem = (item: TestItem) => {
+    setTestItems((prev) => [...prev, item]);
+  };
 
   // Submit handler
   const handleSubmit = (e: React.FormEvent) => {
@@ -38,10 +46,11 @@ export default function ConfigPanel({ onSubmitted }: ConfigPanelProps) {
     setSubmitting(true);
     setFormSubmitted(true);
 
-    emitTestCaseInitiated({
-      testCase,
-      url,
-    });
+      emitTestCaseInitiated({
+        testCase,
+        url,
+        testItems,
+      });
 
     onSubmitted?.(testCase);
   };
@@ -72,6 +81,11 @@ export default function ConfigPanel({ onSubmitted }: ConfigPanelProps) {
   /* Form view (pre-submit) */
   return (
     <div className="w-full flex justify-center items-start p-4 md:p-6 max-w-4xl mx-auto">
+      <TestItemDialog
+        open={showDialog}
+        onClose={() => setShowDialog(false)}
+        onAdd={handleAddItem}
+      />
       <div className="w-full">
         <AppHeader />
 
@@ -112,6 +126,27 @@ export default function ConfigPanel({ onSubmitted }: ConfigPanelProps) {
                   onChange={(e) => setTestCase(e.target.value)}
                   disabled={submitting}
                 />
+              </div>
+
+              <div className="space-y-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setShowDialog(true)}
+                  disabled={submitting}
+                >
+                  Add Test Item
+                </Button>
+                {testItems.length > 0 && (
+                  <ul className="list-disc list-inside text-sm">
+                    {testItems.map((item, idx) => (
+                      <li key={idx}>
+                        {item.url}
+                        {item.text ? ` - ${item.text}` : ""}
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </div>
             </CardContent>
             <CardFooter className="flex justify-between">

--- a/frontend/components/TestItemDialog.tsx
+++ b/frontend/components/TestItemDialog.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import React, { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { TestItem } from "@/types/testItem";
+
+interface TestItemDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onAdd: (item: TestItem) => void;
+}
+
+export default function TestItemDialog({ open, onClose, onAdd }: TestItemDialogProps) {
+  const [form, setForm] = useState<TestItem>({
+    url: "",
+    text: "",
+    color: "",
+    size: "",
+    shouldClick: false,
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const res = await fetch(form.url, { method: "HEAD" });
+      if (!res.ok) {
+        setError("Invalid link");
+        return;
+      }
+    } catch {
+      setError("Invalid link");
+      return;
+    }
+    onAdd(form);
+    setForm({ url: "", text: "", color: "", size: "", shouldClick: false });
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-md rounded-md bg-background p-4 space-y-4">
+        <h2 className="text-lg font-semibold">Add Test Item</h2>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <Label htmlFor="url">Link URL</Label>
+            <Input
+              id="url"
+              type="url"
+              required
+              value={form.url}
+              onChange={(e) => setForm({ ...form, url: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="text">Text</Label>
+            <Input
+              id="text"
+              value={form.text}
+              onChange={(e) => setForm({ ...form, text: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="color">Color</Label>
+            <Input
+              id="color"
+              value={form.color}
+              onChange={(e) => setForm({ ...form, color: e.target.value })}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="size">Size</Label>
+            <Input
+              id="size"
+              value={form.size}
+              onChange={(e) => setForm({ ...form, size: e.target.value })}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              id="shouldClick"
+              type="checkbox"
+              checked={form.shouldClick}
+              onChange={(e) =>
+                setForm({ ...form, shouldClick: e.target.checked })
+              }
+            />
+            <Label htmlFor="shouldClick">Requires click</Label>
+          </div>
+          {error && <p className="text-sm text-red-500">{error}</p>}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button type="button" variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit">Add</Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/types/testItem.ts
+++ b/frontend/types/testItem.ts
@@ -1,0 +1,7 @@
+export interface TestItem {
+  url: string;
+  text: string;
+  color: string;
+  size: string;
+  shouldClick: boolean;
+}


### PR DESCRIPTION
## Summary
- allow adding granular test items from config panel
- validate link availability and capture optional text, color, size and click flag
- include added test items when submitting a test case

## Testing
- `npm run lint --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68a0e3c6198c83328eff7adf6e3d5b39