### PR TITLE
fix: improve test builder strict locators

### DIFF
--- a/frontend/app/test-builder/page.tsx
+++ b/frontend/app/test-builder/page.tsx
@@ -14,6 +14,7 @@ type Item =
       fontFamily?: string;
       fontWeight?: string;
       fontSize?: string;
+      strict?: boolean;
     }
   | { kind: "scroll"; amount: number };
 
@@ -32,6 +33,7 @@ export default function TestBuilder() {
     fontFamily: "",
     fontWeight: "",
     fontSize: "",
+    strict: false,
   });
   const [specText, setSpecText] = useState("");
   const [specEdited, setSpecEdited] = useState(false);
@@ -65,6 +67,7 @@ export default function TestBuilder() {
       fontFamily: "",
       fontWeight: "",
       fontSize: "",
+      strict: false,
     });
   };
 
@@ -80,6 +83,7 @@ export default function TestBuilder() {
         fontFamily: formData.fontFamily.trim() || undefined,
         fontWeight: formData.fontWeight.trim() || undefined,
         fontSize: formData.fontSize.trim() || undefined,
+        strict: formData.strict,
       },
     ]);
     setNewElementTag(null);
@@ -126,9 +130,13 @@ export default function TestBuilder() {
             .replace(/\\/g, "\\\\")
             .replace(/"/g, '\\"')}")`;
           const varName = `locator${idx}`;
-          lines.push(
-            `  const ${varName} = page.locator('${selector}').first();`
-          );
+          if (item.strict) {
+            lines.push(`  const ${varName} = page.locator('${selector}');`);
+          } else {
+            lines.push(
+              `  const ${varName} = page.locator('${selector}').nth(0);`
+            );
+          }
           lines.push(`  await expect(${varName}).toBeVisible();`);
           if (item.color) {
             const color = normalizeColor(item.color);
@@ -363,6 +371,16 @@ export default function TestBuilder() {
                 setFormData({ ...formData, fontSize: e.target.value })
               }
             />
+            <label className="flex items-center space-x-2">
+              <input
+                type="checkbox"
+                checked={formData.strict}
+                onChange={(e) =>
+                  setFormData({ ...formData, strict: e.target.checked })
+                }
+              />
+              <span className="text-sm">Use strict locator</span>
+            </label>
             <div className="flex justify-end space-x-2 pt-2">
               <button
                 type="button"

--- a/frontend/app/test-builder/page.tsx
+++ b/frontend/app/test-builder/page.tsx
@@ -12,6 +12,7 @@ type Item =
       text: string;
       color?: string;
       fontFamily?: string;
+      fontWeight?: string;
       fontSize?: string;
     }
   | { kind: "scroll"; amount: number };
@@ -29,6 +30,7 @@ export default function TestBuilder() {
     text: "",
     color: "",
     fontFamily: "",
+    fontWeight: "",
     fontSize: "",
   });
   const [specText, setSpecText] = useState("");
@@ -57,7 +59,13 @@ export default function TestBuilder() {
 
   const addItem = (type: ElementTag) => {
     setNewElementTag(type);
-    setFormData({ text: "", color: "", fontFamily: "", fontSize: "" });
+    setFormData({
+      text: "",
+      color: "",
+      fontFamily: "",
+      fontWeight: "",
+      fontSize: "",
+    });
   };
 
   const submitItem = () => {
@@ -70,6 +78,7 @@ export default function TestBuilder() {
         text: formData.text.trim(),
         color: formData.color.trim() || undefined,
         fontFamily: formData.fontFamily.trim() || undefined,
+        fontWeight: formData.fontWeight.trim() || undefined,
         fontSize: formData.fontSize.trim() || undefined,
       },
     ]);
@@ -118,7 +127,7 @@ export default function TestBuilder() {
             .replace(/"/g, '\\"')}")`;
           const varName = `locator${idx}`;
           lines.push(
-            `  const ${varName} = page.locator('${selector}', { strict: false });`
+            `  const ${varName} = page.locator('${selector}').first();`
           );
           lines.push(`  await expect(${varName}).toBeVisible();`);
           if (item.color) {
@@ -130,6 +139,11 @@ export default function TestBuilder() {
           if (item.fontFamily) {
             lines.push(
               `  await expect(${varName}).toHaveCSS('font-family', '${item.fontFamily}');`
+            );
+          }
+          if (item.fontWeight) {
+            lines.push(
+              `  await expect(${varName}).toHaveCSS('font-weight', '${item.fontWeight}');`
             );
           }
           if (item.fontSize) {
@@ -260,6 +274,7 @@ export default function TestBuilder() {
                 style={{
                   color: item.color,
                   fontFamily: item.fontFamily,
+                  fontWeight: item.fontWeight,
                   fontSize: item.fontSize,
                 }}
               >
@@ -330,6 +345,14 @@ export default function TestBuilder() {
               value={formData.fontFamily}
               onChange={(e) =>
                 setFormData({ ...formData, fontFamily: e.target.value })
+              }
+            />
+            <input
+              className="w-full border px-2 py-1"
+              placeholder="Font weight (optional)"
+              value={formData.fontWeight}
+              onChange={(e) =>
+                setFormData({ ...formData, fontWeight: e.target.value })
               }
             />
             <input


### PR DESCRIPTION
## Summary
- avoid Playwright strict locator violations by selecting the first match instead of passing `strict: false`
- allow generated tests to assert `font-weight` via new `fontWeight` field

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a10255c48883328d35cc5484181645