### PR TITLE
feat: enhance test builder with blue buttons

### DIFF
--- a/frontend/app/test-builder/page.tsx
+++ b/frontend/app/test-builder/page.tsx
@@ -247,8 +247,8 @@ export default function TestBuilder() {
 
   return (
     <div className="flex h-full">
-      <aside className="w-48 p-4 border-r space-y-2 bg-secondary">
-        <Button onClick={setRouteHandler} className="w-full">
+      <aside className="w-48 p-4 border-r space-y-2 bg-blue-50">
+        <Button onClick={setRouteHandler} className="w-full" variant="builder">
           Set Route
         </Button>
         {tests.map((t, idx) => (
@@ -256,12 +256,12 @@ export default function TestBuilder() {
             key={idx}
             onClick={() => setCurrentTest(idx)}
             className="w-full"
-            variant={idx === currentTest ? "default" : "secondary"}
+            variant={idx === currentTest ? "builder" : "secondary"}
           >
             {t.name}
           </Button>
         ))}
-        <Button onClick={addTestCase} className="w-full">
+        <Button onClick={addTestCase} className="w-full" variant="builder">
           Add Test Case
         </Button>
         {ELEMENTS.map((el) => (
@@ -269,12 +269,12 @@ export default function TestBuilder() {
             key={el}
             onClick={() => addItem(el)}
             className="w-full"
-            variant="secondary"
+            variant="builder"
           >
             {el.toUpperCase()}
           </Button>
         ))}
-        <Button onClick={addScroll} className="w-full" variant="secondary">
+        <Button onClick={addScroll} className="w-full" variant="builder">
           Scroll
         </Button>
         {(hasAnyItems || tests[currentTest].items.length > 0) && (
@@ -284,14 +284,14 @@ export default function TestBuilder() {
                 <Button
                   onClick={copySpec}
                   className="w-full"
-                  variant="secondary"
+                  variant="builder"
                 >
                   Copy Tests
                 </Button>
                 <Button
                   onClick={downloadSpec}
                   className="w-full"
-                  variant="secondary"
+                  variant="builder"
                 >
                   Download Tests
                 </Button>
@@ -352,7 +352,7 @@ export default function TestBuilder() {
             {specEdited && (
               <Button
                 onClick={regenerateSpec}
-                variant="secondary"
+                variant="builder"
                 className="mt-2"
               >
                 Reset to Generated Code
@@ -486,7 +486,7 @@ export default function TestBuilder() {
                 >
                   Cancel
                 </Button>
-                <Button type="submit">Add</Button>
+                <Button type="submit" variant="builder">Add</Button>
               </CardFooter>
             </form>
           </Card>

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -11,6 +11,8 @@ const buttonVariants = cva(
       variant: {
         default:
           'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+        builder:
+          'bg-blue-500 text-white shadow hover:bg-blue-600 focus-visible:ring-blue-500',
         destructive:
           'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
         outline:


### PR DESCRIPTION
## Summary
- add dedicated blue `builder` button variant with hover styling
- apply new variant throughout the test builder panel

## Testing
- `npm test --prefix frontend` (fails: Missing script: "test")
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68a11f803bb083329adcc94bf1f4b585