### PR TITLE
feat: allow exact text matching

### DIFF
--- a/cua-server/src/handlers/cua-loop-handler.ts
+++ b/cua-server/src/handlers/cua-loop-handler.ts
@@ -24,7 +24,11 @@ async function executeTestItems(
     try {
       let locator;
       if (item.text) {
-        locator = page.getByText(item.text);
+        // Allow callers to specify whether to look for an exact text match or
+        // just check if the element contains the given text. Default behavior
+        // is a substring match.
+        const exact = item.textMatch === "exact";
+        locator = page.getByText(item.text, { exact });
       } else if (item.url) {
         locator = page.locator(`a[href="${item.url}"]`);
       } else {

--- a/cua-server/src/types/test-item.ts
+++ b/cua-server/src/types/test-item.ts
@@ -9,4 +9,9 @@ export interface TestItem {
   fontType?: string;
   navigationUrl?: string;
   eventName?: string;
+  /**
+   * How text should be matched on the page. Defaults to substring matching
+   * ("contains") when not specified.
+   */
+  textMatch?: "exact" | "contains";
 }

--- a/frontend/components/TestItemDialog.tsx
+++ b/frontend/components/TestItemDialog.tsx
@@ -24,6 +24,7 @@ export default function TestItemDialog({ open, onClose, onAdd }: TestItemDialogP
     fontType: "",
     navigationUrl: "",
     eventName: "",
+    textMatch: "contains",
   });
   const [error, setError] = useState<string | null>(null);
 
@@ -54,6 +55,7 @@ export default function TestItemDialog({ open, onClose, onAdd }: TestItemDialogP
       fontType: "",
       navigationUrl: "",
       eventName: "",
+      textMatch: "contains",
     });
     onClose();
   };
@@ -80,6 +82,20 @@ export default function TestItemDialog({ open, onClose, onAdd }: TestItemDialogP
               value={form.text}
               onChange={(e) => setForm({ ...form, text: e.target.value })}
             />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="textMatch">Text Match</Label>
+            <select
+              id="textMatch"
+              value={form.textMatch}
+              onChange={(e) =>
+                setForm({ ...form, textMatch: e.target.value as "contains" | "exact" })
+              }
+              className="w-full rounded-md border px-2 py-1"
+            >
+              <option value="contains">Contains</option>
+              <option value="exact">Exact</option>
+            </select>
           </div>
           <div className="space-y-2">
             <Label htmlFor="fontColor">Font Color</Label>

--- a/frontend/types/testItem.ts
+++ b/frontend/types/testItem.ts
@@ -9,4 +9,9 @@ export interface TestItem {
   fontType?: string;
   navigationUrl?: string;
   eventName?: string;
+  /**
+   * Whether the supplied text should be matched exactly or as a substring.
+   * Defaults to "contains" when omitted.
+   */
+  textMatch?: "exact" | "contains";
 }


### PR DESCRIPTION
## Summary
- allow specifying exact or partial text checks when running Playwright tests
- add `textMatch` option to test items, defaulting to substring matching
- update Test Item dialog to let users choose between "contains" and "exact"

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint --prefix frontend`
- `npm run build --prefix cua-server` (fails: Cannot find module 'openai' or its corresponding type declarations)

------
https://chatgpt.com/codex/tasks/task_e_68a12189a28483329276c01ea90acafd