### PR TITLE
feat: allow configuring model and element type for test items

### DIFF
--- a/cua-server/src/agents/test-case-agent.ts
+++ b/cua-server/src/agents/test-case-agent.ts
@@ -19,12 +19,13 @@ export type TestCase = z.infer<typeof TestCaseSchema>;
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 class TestCaseAgent {
-  private readonly model = "o3-mini";
+  private readonly model: string;
   private readonly developer_prompt: string;
   private readonly login_required: boolean;
 
-  constructor(login_required = false) {
+  constructor(login_required = false, model = "o3-mini") {
     this.login_required = login_required;
+    this.model = model;
     this.developer_prompt = login_required
       ? PROMPT_WITH_LOGIN
       : PROMPT_WITHOUT_LOGIN;

--- a/cua-server/src/agents/test-script-review-agent.ts
+++ b/cua-server/src/agents/test-script-review-agent.ts
@@ -40,9 +40,9 @@ class TestScriptReviewAgent {
   private taskQueue: Task[] = [];
   private processingQueue: boolean = false;
 
-  constructor() {
-    // Set the default model to "gpt-4o"
-    this.model = "gpt-4o";
+  constructor(model: string = "gpt-4o") {
+    // Set the default model, allowing override
+    this.model = model;
 
     // Maintain the previous response id.
     this.previous_response_id = null;

--- a/cua-server/src/handlers/cua-loop-handler.ts
+++ b/cua-server/src/handlers/cua-loop-handler.ts
@@ -23,7 +23,17 @@ async function executeTestItems(
   for (const item of testItems) {
     try {
       let locator;
-      if (item.text) {
+      if (item.elementType) {
+        if (item.text) {
+          const selector =
+            item.textMatch === "exact"
+              ? `${item.elementType}:text-is("${item.text}")`
+              : `${item.elementType}:has-text("${item.text}")`;
+          locator = page.locator(selector);
+        } else {
+          locator = page.locator(item.elementType);
+        }
+      } else if (item.text) {
         // Allow callers to specify whether to look for an exact text match or
         // just check if the element contains the given text. Default behavior
         // is a substring match.

--- a/cua-server/src/handlers/test-case-initiation-handler.ts
+++ b/cua-server/src/handlers/test-case-initiation-handler.ts
@@ -19,6 +19,7 @@ export async function handleTestCaseInitiated(
       password,
       userInfo,
       testItems,
+      model,
     } = data as {
       testCase: string;
       url: string;
@@ -27,6 +28,7 @@ export async function handleTestCaseInitiated(
       userInfo: string;
       testItems?: TestItem[];
       loginRequired?: boolean;
+      model?: string;
     };
     const loginRequired = data.loginRequired ?? true;
 
@@ -43,13 +45,13 @@ export async function handleTestCaseInitiated(
     // Create system prompt by combining form inputs.
     const msg = `${testCase} URL: ${url} User Name: ${userName} Password: *********\n USER INFO:\n${userInfo}`;
 
-    const testCaseAgent = new TestCaseAgent(loginRequired);
+    const testCaseAgent = new TestCaseAgent(loginRequired, model);
 
     const testCaseResponse = await testCaseAgent.invokeResponseAPI(msg);
     const testCaseJson = JSON.stringify(testCaseResponse);
 
     // Create a new test case review agent.
-    const testCaseReviewAgent = new TestScriptReviewAgent();
+    const testCaseReviewAgent = new TestScriptReviewAgent(model);
 
     logger.debug(
       `Invoking test script review agent - This should only be called once per test script run.`

--- a/cua-server/src/types/test-item.ts
+++ b/cua-server/src/types/test-item.ts
@@ -2,6 +2,8 @@ export interface TestItem {
   url: string;
   text: string;
   shouldClick: boolean;
+  /** Optional HTML element tag, e.g. "button" or "h1". */
+  elementType?: string;
   /**
    * Optional label associated with an input box. Used to locate the input by its
    * visible label.

--- a/frontend/components/ConfigPanel.tsx
+++ b/frontend/components/ConfigPanel.tsx
@@ -30,6 +30,7 @@ interface ConfigPanelProps {
 export default function ConfigPanel({ onSubmitted }: ConfigPanelProps) {
   const { testCase, setTestCase } = useTestCaseStore();
   const [url, setUrl] = useState(TEST_APP_URL);
+  const [model, setModel] = useState("o3-mini");
   const [submitting, setSubmitting] = useState(false);
   const [formSubmitted, setFormSubmitted] = useState(false);
   const [testItems, setTestItems] = useState<TestItem[]>([]);
@@ -51,6 +52,7 @@ export default function ConfigPanel({ onSubmitted }: ConfigPanelProps) {
         testCase,
         url,
         testItems,
+        model,
       });
 
     onSubmitted?.(testCase);
@@ -117,6 +119,21 @@ export default function ConfigPanel({ onSubmitted }: ConfigPanelProps) {
                   className="flex-1"
                 />
               </div>
+              <div className="flex items-center gap-3">
+                <Label
+                  htmlFor="model"
+                  className="flex items-center gap-2 whitespace-nowrap w-24"
+                >
+                  Model
+                </Label>
+                <Input
+                  id="model"
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                  disabled={submitting}
+                  className="flex-1"
+                />
+              </div>
 
               <div className="space-y-2">
                 <Label htmlFor="test-case">Test instructions</Label>
@@ -142,6 +159,7 @@ export default function ConfigPanel({ onSubmitted }: ConfigPanelProps) {
                   <ul className="list-disc list-inside text-sm">
                     {testItems.map((item, idx) => (
                       <li key={idx}>
+                        {item.elementType ? `${item.elementType} ` : ""}
                         {item.url}
                         {item.text ? ` - ${item.text}` : ""}
                         {(item.inputLabel || item.testId) &&

--- a/frontend/components/TestItemDialog.tsx
+++ b/frontend/components/TestItemDialog.tsx
@@ -17,6 +17,7 @@ export default function TestItemDialog({ open, onClose, onAdd }: TestItemDialogP
     url: "",
     text: "",
     shouldClick: false,
+    elementType: "",
     inputLabel: "",
     testId: "",
     inputValue: "",
@@ -51,6 +52,7 @@ export default function TestItemDialog({ open, onClose, onAdd }: TestItemDialogP
       url: "",
       text: "",
       shouldClick: false,
+      elementType: "",
       inputLabel: "",
       testId: "",
       inputValue: "",
@@ -81,13 +83,26 @@ export default function TestItemDialog({ open, onClose, onAdd }: TestItemDialogP
               onChange={(e) => setForm({ ...form, url: e.target.value })}
             />
           </div>
-          <div className="space-y-2">
+        <div className="space-y-2">
             <Label htmlFor="text">Text</Label>
             <Input
               id="text"
               value={form.text}
               onChange={(e) => setForm({ ...form, text: e.target.value })}
             />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="elementType">Element Type</Label>
+            <select
+              id="elementType"
+              value={form.elementType}
+              onChange={(e) => setForm({ ...form, elementType: e.target.value })}
+              className="w-full rounded-md border px-2 py-1"
+            >
+              <option value="">None</option>
+              <option value="button">button</option>
+              <option value="h1">h1</option>
+            </select>
           </div>
           <div className="space-y-2">
             <Label htmlFor="textMatch">Text Match</Label>

--- a/frontend/types/testItem.ts
+++ b/frontend/types/testItem.ts
@@ -2,6 +2,8 @@ export interface TestItem {
   url: string;
   text: string;
   shouldClick: boolean;
+  /** Optional HTML element tag, e.g. "button" or "h1". */
+  elementType?: string;
   /**
    * Optional label associated with an input box. Used to locate the input by its
    * visible label.


### PR DESCRIPTION
## Summary
- add optional `elementType` to test items and expose in dialog
- allow selecting OpenAI model in test configuration
- propagate model and element type through server handlers

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a142b49af083328db7bb4ccbabecdb