### PR TITLE
feat(test-builder): add input element option

### DIFF
--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -12,13 +12,13 @@ const buttonVariants = cva(
         default:
           'bg-primary text-primary-foreground shadow hover:bg-primary/90',
         builder:
-          'bg-blue-500 text-white shadow hover:bg-blue-600 focus-visible:ring-blue-500',
+          'bg-indigo-600 text-white shadow hover:bg-indigo-700 focus-visible:ring-indigo-500',
         destructive:
           'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
         outline:
           'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
         secondary:
-          'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+          'bg-slate-700 text-slate-100 shadow-sm hover:bg-slate-600',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline'
       },


### PR DESCRIPTION
## Summary
- add input to selectable elements in test builder
- handle placeholder-based selectors for input elements
- render input preview with placeholder text
- refine color palette and make sidebar scrollable

## Testing
- `npm test` (fails: Missing script: "test")
- `npm test --prefix frontend` (fails: Missing script: "test")
- `npm run lint` (fails: Missing script: "lint")
- `npm run lint --prefix frontend` (fails: sh: 1: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a1482a32dc83328cb9eb0dcda5a5d9