### PR TITLE
Return generated Playwright script to frontend

### DIFF
--- a/cua-server/.gitignore
+++ b/cua-server/.gitignore
@@ -19,6 +19,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store

--- a/cua-server/src/agents/playwright-code-agent.ts
+++ b/cua-server/src/agents/playwright-code-agent.ts
@@ -1,0 +1,28 @@
+import OpenAI from "openai";
+import logger from "../utils/logger";
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+class PlaywrightCodeAgent {
+  private readonly model = "gpt-4.1-mini";
+
+  async generateCode(instructions: string): Promise<string> {
+    logger.debug("Generating Playwright code", { instructions });
+    const response = await openai.responses.create({
+      model: this.model,
+      input: [
+        {
+          role: "system",
+          content:
+            "You convert test descriptions into runnable Playwright test scripts. Return only TypeScript code.",
+        },
+        { role: "user", content: instructions },
+      ],
+    });
+    const code = response.output_text || "";
+    logger.debug("Generated code", { code });
+    return code.trim();
+  }
+}
+
+export default PlaywrightCodeAgent;

--- a/cua-server/src/handlers/test-case-initiation-handler.ts
+++ b/cua-server/src/handlers/test-case-initiation-handler.ts
@@ -4,6 +4,7 @@ import TestCaseAgent from "../agents/test-case-agent";
 import { convertTestCaseToSteps, TestCase } from "../utils/testCaseUtils";
 import { cuaLoopHandler } from "./cua-loop-handler";
 import TestScriptReviewAgent from "../agents/test-script-review-agent";
+import PlaywrightCodeAgent from "../agents/playwright-code-agent";
 
 export async function handleTestCaseInitiated(
   socket: Socket,
@@ -67,6 +68,11 @@ export async function handleTestCaseInitiated(
     const testScript = convertTestCaseToSteps(testCaseResponse as TestCase);
 
     logger.debug(`Test script: ${testScript}`);
+
+    // Generate Playwright code for the test script and send to client
+    const playwrightAgent = new PlaywrightCodeAgent();
+    const code = await playwrightAgent.generateCode(testScript);
+    socket.emit("testcode", code);
 
     // Start the test execution using the provided URL.
     // Pass the test case review agent to the cuaLoopHandler.

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import ConfigPanel from "@/components/ConfigPanel";
 import SidePanel from "@/components/SidePanel";
 import TaskSteps from "@/components/TaskSteps";
+import GeneratedCode from "@/components/GeneratedCode";
 
 export default function Main() {
   const [isSideOpen, setIsSideOpen] = useState(false);
@@ -44,6 +45,7 @@ export default function Main() {
           <ConfigPanel onSubmitted={() => setConfigSubmitted(true)} />
 
           {/* Show task-steps only after the config has been submitted */}
+          {configSubmitted && <GeneratedCode />}
           {configSubmitted && <TaskSteps />}
         </div>
 

--- a/frontend/components/GeneratedCode.tsx
+++ b/frontend/components/GeneratedCode.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import useCodeStore from "@/stores/useCodeStore";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { duotoneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
+
+export default function GeneratedCode() {
+  const code = useCodeStore((s) => s.testCode);
+  if (!code) return null;
+  return (
+    <div className="max-w-4xl mx-auto p-4 md:p-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Generated Playwright Code</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <SyntaxHighlighter
+            language="typescript"
+            style={duotoneLight}
+            showLineNumbers
+          >
+            {code}
+          </SyntaxHighlighter>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/components/SocketIOManager.tsx
+++ b/frontend/components/SocketIOManager.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import io, { Socket } from "socket.io-client";
 
 import useConversationStore from "@/stores/useConversationStore";
 import useTaskStore from "@/stores/useTaskStore";
+import useCodeStore from "@/stores/useCodeStore";
 
 /** One singleton client socket. */
 let socket: Socket | null = null;
@@ -31,6 +32,7 @@ export function SocketIOManager() {
   );
   const setTestCases = useTaskStore((s) => s.setTestCases);
   const updateTestScript = useTaskStore((s) => s.updateTestScript);
+  const setTestCode = useCodeStore((s) => s.setTestCode);
 
   useEffect(() => {
     // Connect to standalone WebSocket server
@@ -50,6 +52,10 @@ export function SocketIOManager() {
         } catch (err) {
           console.error("✖ parse testcases", err);
         }
+      });
+
+      socket.on("testcode", (code: string) => {
+        setTestCode(code);
       });
 
       /* step‑by‑step status updates */
@@ -82,7 +88,13 @@ export function SocketIOManager() {
       socket?.disconnect();
       socket = null;
     };
-  }, [addChatMessage, addConversationItem, setTestCases, updateTestScript]);
+  }, [
+    addChatMessage,
+    addConversationItem,
+    setTestCases,
+    updateTestScript,
+    setTestCode,
+  ]);
 
   return null;
 }

--- a/frontend/stores/useCodeStore.ts
+++ b/frontend/stores/useCodeStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface CodeStoreState {
+  testCode: string;
+  setTestCode: (code: string) => void;
+}
+
+export const useCodeStore = create<CodeStoreState>((set) => ({
+  testCode: "",
+  setTestCode: (code) => set({ testCode: code }),
+}));
+
+export default useCodeStore;


### PR DESCRIPTION
## Summary
- generate Playwright tests from natural language via new server agent
- emit generated code to clients and display it in UI

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint` (frontend)
- `npm test` (cua-server) *(fails: Missing script: "test")*
- `npm run build` (cua-server) *(fails: Cannot find module type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a14f26f06c8332ac81a7be219a6bfa