### PR TITLE
feat: add AI-generated Playwright test case page

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
 import { SocketIOManager } from "@/components/SocketIOManager";
+import Link from "next/link";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -31,6 +32,10 @@ export default function RootLayout({
         <SocketIOManager />
 
         <div className="flex flex-col h-screen overflow-hidden bg-background text-foreground">
+          <nav className="p-4 border-b border-border flex gap-4">
+            <Link href="/test-builder">Test Builder</Link>
+            <Link href="/testcase">Test Case Generator</Link>
+          </nav>
           <main className="flex-1 min-h-0 flex flex-col">{children}</main>
         </div>
       </body>

--- a/frontend/app/testcase/page.tsx
+++ b/frontend/app/testcase/page.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+
+export default function TestCaseGenerator() {
+  const [scenario, setScenario] = useState("");
+  const [code, setCode] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const generate = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("http://localhost:4000/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scenario }),
+      });
+      const data = await res.json();
+      setCode(data.testCase || "");
+    } catch (err) {
+      console.error("generate", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      <Textarea
+        placeholder="Describe the scenario to test"
+        value={scenario}
+        onChange={(e) => setScenario(e.target.value)}
+        className="bg-slate-800 text-slate-100 border-slate-700"
+        rows={5}
+      />
+      <Button
+        onClick={generate}
+        disabled={loading || !scenario.trim()}
+        variant="builder"
+      >
+        {loading ? "Generating..." : "Generate Test"}
+      </Button>
+      <Textarea
+        placeholder="Playwright test code will appear here"
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+        className="font-mono bg-slate-800 text-slate-100 border-slate-700 min-h-[200px]"
+      />
+    </div>
+  );
+}
+

--- a/testcase-server/package.json
+++ b/testcase-server/package.json
@@ -8,12 +8,14 @@
   },
   "dependencies": {
     "express": "^4.19.2",
-    "openai": "^4.87.3"
+    "openai": "^4.87.3",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "typescript": "^5",
     "ts-node-dev": "^2.0.0",
     "@types/node": "^20",
-    "@types/express": "^4.17.17"
+    "@types/express": "^4.17.17",
+    "@types/cors": "^2.8.17"
   }
 }

--- a/testcase-server/src/index.ts
+++ b/testcase-server/src/index.ts
@@ -1,10 +1,12 @@
 import express from "express";
 import { config } from "dotenv";
 import OpenAI from "openai";
+import cors from "cors";
 
 config({ path: ".env.development" });
 
 const app = express();
+app.use(cors());
 app.use(express.json());
 
 const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });


### PR DESCRIPTION
## Summary
- add CORS to testcase server to allow browser requests
- create frontend page to request Playwright tests from testcase server

## Testing
- `npm run lint --prefix frontend` (fails: next not found)
- `npm run build --prefix testcase-server` (fails: missing type definitions)

------
https://chatgpt.com/codex/tasks/task_e_68a154d4ee248332a46a3d3706d3b22d