### PR TITLE
feat: add test generator panel to main page

### DIFF
--- a/frontend/app/test-builder/page.tsx
+++ b/frontend/app/test-builder/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import TestCaseGenerator from "@/components/TestCaseGenerator";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -331,72 +332,77 @@ export default function TestBuilder() {
           </div>
         )}
       </aside>
-      <main className="flex-1 p-4 overflow-auto">
-        {tests[currentTest].items.map((item, idx) => {
-          if (item.kind === "element") {
-            if (item.type === "input") {
+      <main className="flex-1 flex">
+        <div className="flex-1 p-4 overflow-auto">
+          {tests[currentTest].items.map((item, idx) => {
+            if (item.kind === "element") {
+              if (item.type === "input") {
+                return (
+                  <input
+                    key={idx}
+                    className="mb-2 px-2 py-1 rounded bg-slate-800 border border-slate-700 text-slate-100"
+                    placeholder={item.text}
+                    style={{
+                      color: item.color,
+                      fontFamily: item.fontFamily,
+                      fontWeight: item.fontWeight,
+                      fontSize: item.fontSize,
+                    }}
+                  />
+                );
+              }
+              const Tag = item.type as keyof JSX.IntrinsicElements;
+              const anchorProps =
+                item.type === "a" && item.href ? { href: item.href } : {};
               return (
-                <input
+                <Tag
                   key={idx}
-                  className="mb-2 px-2 py-1 rounded bg-slate-800 border border-slate-700 text-slate-100"
-                  placeholder={item.text}
+                  className="mb-2"
                   style={{
                     color: item.color,
                     fontFamily: item.fontFamily,
                     fontWeight: item.fontWeight,
                     fontSize: item.fontSize,
                   }}
-                />
+                  {...anchorProps}
+                >
+                  {item.text}
+                </Tag>
               );
             }
-            const Tag = item.type as keyof JSX.IntrinsicElements;
-            const anchorProps =
-              item.type === "a" && item.href ? { href: item.href } : {};
             return (
-              <Tag
-                key={idx}
-                className="mb-2"
-                style={{
-                  color: item.color,
-                  fontFamily: item.fontFamily,
-                  fontWeight: item.fontWeight,
-                  fontSize: item.fontSize,
-                }}
-                {...anchorProps}
-              >
-                {item.text}
-              </Tag>
+              <p key={idx} className="mb-2 text-slate-400">
+                Scroll {item.amount}px
+              </p>
             );
-          }
-          return (
-            <p key={idx} className="mb-2 text-slate-400">
-              Scroll {item.amount}px
-            </p>
-          );
-        })}
-        {hasAnyItems && (
-          <div className="mt-4">
-            <h2 className="font-semibold mb-2">Generated Test Suite</h2>
-            <Textarea
-              className="font-mono bg-slate-800 text-slate-100 border-slate-700"
-              rows={10}
-              value={specText}
-              onChange={(e) => {
-                setSpecEdited(true);
-                setSpecText(e.target.value);
-              }}
-            />
-            {specEdited && (
-              <Button
-                onClick={regenerateSpec}
-                variant="builder"
-                className="mt-2"
-              >
-                Reset to Generated Code
-              </Button>
-            )}
-          </div>
-        )}
+          })}
+          {hasAnyItems && (
+            <div className="mt-4">
+              <h2 className="font-semibold mb-2">Generated Test Suite</h2>
+              <Textarea
+                className="font-mono bg-slate-800 text-slate-100 border-slate-700"
+                rows={10}
+                value={specText}
+                onChange={(e) => {
+                  setSpecEdited(true);
+                  setSpecText(e.target.value);
+                }}
+              />
+              {specEdited && (
+                <Button
+                  onClick={regenerateSpec}
+                  variant="builder"
+                  className="mt-2"
+                >
+                  Reset to Generated Code
+                </Button>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="w-96 p-4 border-l border-slate-700 overflow-auto bg-slate-900">
+          <TestCaseGenerator />
+        </div>
       </main>
       {newElementTag && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">

--- a/frontend/app/testcase/page.tsx
+++ b/frontend/app/testcase/page.tsx
@@ -1,53 +1,11 @@
 "use client";
 
-import { useState } from "react";
-import { Textarea } from "@/components/ui/textarea";
-import { Button } from "@/components/ui/button";
+import TestCaseGenerator from "@/components/TestCaseGenerator";
 
-export default function TestCaseGenerator() {
-  const [scenario, setScenario] = useState("");
-  const [code, setCode] = useState("");
-  const [loading, setLoading] = useState(false);
-
-  const generate = async () => {
-    setLoading(true);
-    try {
-      const res = await fetch("http://localhost:4000/generate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ scenario }),
-      });
-      const data = await res.json();
-      setCode(data.testCase || "");
-    } catch (err) {
-      console.error("generate", err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
+export default function TestCasePage() {
   return (
-    <div className="max-w-2xl mx-auto p-4 space-y-4">
-      <Textarea
-        placeholder="Describe the scenario to test"
-        value={scenario}
-        onChange={(e) => setScenario(e.target.value)}
-        className="bg-slate-800 text-slate-100 border-slate-700"
-        rows={5}
-      />
-      <Button
-        onClick={generate}
-        disabled={loading || !scenario.trim()}
-        variant="builder"
-      >
-        {loading ? "Generating..." : "Generate Test"}
-      </Button>
-      <Textarea
-        placeholder="Playwright test code will appear here"
-        value={code}
-        onChange={(e) => setCode(e.target.value)}
-        className="font-mono bg-slate-800 text-slate-100 border-slate-700 min-h-[200px]"
-      />
+    <div className="max-w-2xl mx-auto p-4">
+      <TestCaseGenerator />
     </div>
   );
 }

--- a/frontend/components/TestCaseGenerator.tsx
+++ b/frontend/components/TestCaseGenerator.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState } from "react";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+
+export default function TestCaseGenerator() {
+  const [scenario, setScenario] = useState("");
+  const [code, setCode] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const generate = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("http://localhost:4000/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scenario }),
+      });
+      const data = await res.json();
+      setCode(data.testCase || "");
+    } catch (err) {
+      console.error("generate", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <Textarea
+        placeholder="Describe the scenario to test"
+        value={scenario}
+        onChange={(e) => setScenario(e.target.value)}
+        className="bg-slate-800 text-slate-100 border-slate-700"
+        rows={5}
+      />
+      <Button
+        onClick={generate}
+        disabled={loading || !scenario.trim()}
+        variant="builder"
+        className="w-full"
+      >
+        {loading ? "Generating..." : "Generate Test"}
+      </Button>
+      <Textarea
+        placeholder="Playwright test code will appear here"
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+        className="font-mono bg-slate-800 text-slate-100 border-slate-700 min-h-[200px]"
+      />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `TestCaseGenerator` component for generating playwright test code
- render generator on the right side of test builder UI
- use shared generator component on `/testcase`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next not found)


------
https://chatgpt.com/codex/tasks/task_e_68a226219a0c8332bac0327c5d522b53