### PR TITLE
fix: avoid failing when .env.development is missing

### DIFF
--- a/cua-server/package.json
+++ b/cua-server/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "ts-node-dev --env-file=.env.development --respawn --transpile-only src/index.ts"
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts"
   },
   "dependencies": {
     "socket.io": "^4.8.1",

--- a/cua-server/src/utils/logger.ts
+++ b/cua-server/src/utils/logger.ts
@@ -1,4 +1,7 @@
+import { config } from "dotenv";
 import pino from "pino";
+
+config({ path: ".env.development" });
 
 const isProduction = process.env.NODE_ENV === "production";
 

--- a/testcase-server/package.json
+++ b/testcase-server/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "ts-node-dev --env-file=.env.development --respawn --transpile-only src/index.ts"
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts"
   },
   "dependencies": {
     "express": "^4.19.2",


### PR DESCRIPTION
## Summary
- don't require `.env.development` for testcase server dev script
- drop `--env-file` from cua server dev script and load dotenv manually

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build --prefix testcase-server`
- `npm run build --prefix cua-server` *(fails: TS2345 type errors)*
- `OPENAI_API_KEY=dummy timeout 5 npm run dev:testcase-server`
- `OPENAI_API_KEY=dummy timeout 5 npm run dev:cua-server`


------
https://chatgpt.com/codex/tasks/task_e_68a22b96e3948332b1ec44a1292a2c14