### PR TITLE
Add light mode toggle to test builder

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from "next/font/local";
 import "./globals.css";
 import { SocketIOManager } from "@/components/SocketIOManager";
 import Link from "next/link";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -32,9 +33,10 @@ export default function RootLayout({
         <SocketIOManager />
 
         <div className="flex flex-col h-screen overflow-hidden bg-background text-foreground">
-          <nav className="p-4 border-b border-border flex gap-4">
+          <nav className="p-4 border-b border-border flex gap-4 items-center">
             <Link href="/test-builder">Test Builder</Link>
             <Link href="/testcase">Test Case Generator</Link>
+            <ThemeToggle />
           </nav>
           <main className="flex-1 min-h-0 flex flex-col">{children}</main>
         </div>

--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Switch } from "@/components/ui/switch";
+
+export function ThemeToggle() {
+  const [isDark, setIsDark] = useState(true);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    const prefersDark =
+      stored === "dark" ||
+      (!stored && window.matchMedia("(prefers-color-scheme: dark)").matches);
+    document.documentElement.classList.toggle("dark", prefersDark);
+    setIsDark(prefersDark);
+  }, []);
+
+  function onToggle(checked: boolean) {
+    document.documentElement.classList.toggle("dark", checked);
+    localStorage.setItem("theme", checked ? "dark" : "light");
+    setIsDark(checked);
+  }
+
+  return (
+    <div className="ml-auto flex items-center">
+      <Switch checked={isDark} onCheckedChange={onToggle} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add ThemeToggle component
- expose toggle in layout navigation

## Testing
- `npm test --workspace frontend` (fails: Missing script "test")
- `npm run lint --workspace frontend` (fails: next not found; dependency install returned 403)


------
https://chatgpt.com/codex/tasks/task_e_68a3a4dd26ec833284f4d369bb53331e