### PR TITLE
Add light mode toggle to test builder

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from "next/font/local";
 import "./globals.css";
 import { SocketIOManager } from "@/components/SocketIOManager";
 import Link from "next/link";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -32,9 +33,10 @@ export default function RootLayout({
         <SocketIOManager />
 
         <div className="flex flex-col h-screen overflow-hidden bg-background text-foreground">
-          <nav className="p-4 border-b border-border flex gap-4">
+          <nav className="p-4 border-b border-border flex gap-4 items-center">
             <Link href="/test-builder">Test Builder</Link>
             <Link href="/testcase">Test Case Generator</Link>
+            <ThemeToggle />
           </nav>
           <main className="flex-1 min-h-0 flex flex-col">{children}</main>
         </div>

--- a/frontend/app/test-builder/page.tsx
+++ b/frontend/app/test-builder/page.tsx
@@ -269,8 +269,8 @@ export default function TestBuilder() {
   };
 
   return (
-    <div className="flex h-screen bg-slate-900 text-slate-100">
-      <aside className="w-48 p-4 border-r border-slate-700 space-y-2 bg-slate-800 overflow-y-auto">
+    <div className="flex h-screen bg-background text-foreground">
+      <aside className="w-48 p-4 border-r border-border space-y-2 bg-card overflow-y-auto">
         <Button onClick={setRouteHandler} className="w-full" variant="builder">
           Set Route
         </Button>
@@ -340,7 +340,7 @@ export default function TestBuilder() {
                 return (
                   <input
                     key={idx}
-                    className="mb-2 px-2 py-1 rounded bg-slate-800 border border-slate-700 text-slate-100"
+                    className="mb-2 px-2 py-1 rounded border border-border bg-input text-foreground"
                     placeholder={item.text}
                     style={{
                       color: item.color,
@@ -371,7 +371,7 @@ export default function TestBuilder() {
               );
             }
             return (
-              <p key={idx} className="mb-2 text-slate-400">
+              <p key={idx} className="mb-2 text-muted-foreground">
                 Scroll {item.amount}px
               </p>
             );
@@ -380,7 +380,7 @@ export default function TestBuilder() {
             <div className="mt-4">
               <h2 className="font-semibold mb-2">Generated Test Suite</h2>
               <Textarea
-                className="font-mono bg-slate-800 text-slate-100 border-slate-700"
+                className="font-mono bg-card text-foreground border-border"
                 rows={10}
                 value={specText}
                 onChange={(e) => {
@@ -400,13 +400,13 @@ export default function TestBuilder() {
             </div>
           )}
         </div>
-        <div className="w-96 p-4 border-l border-slate-700 overflow-auto bg-slate-900">
+        <div className="w-96 p-4 border-l border-border overflow-auto bg-card">
           <TestCaseGenerator />
         </div>
       </main>
       {newElementTag && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <Card className="w-80 bg-slate-800 text-slate-100 border-slate-700">
+        <div className="fixed inset-0 bg-background/80 flex items-center justify-center z-50">
+          <Card className="w-80">
             <form
               onSubmit={(e) => {
                 e.preventDefault();
@@ -418,7 +418,6 @@ export default function TestBuilder() {
               </CardHeader>
               <CardContent className="space-y-2">
                 <Input
-                  className="bg-slate-700 border-slate-600"
                   placeholder="Text"
                   value={formData.text}
                   onChange={(e) =>
@@ -426,7 +425,6 @@ export default function TestBuilder() {
                   }
                 />
                 <Input
-                  className="bg-slate-700 border-slate-600"
                   placeholder="Color (optional)"
                   value={formData.color}
                   onChange={(e) =>
@@ -434,7 +432,6 @@ export default function TestBuilder() {
                   }
                 />
                 <Input
-                  className="bg-slate-700 border-slate-600"
                   placeholder="Font family (optional)"
                   value={formData.fontFamily}
                   onChange={(e) =>
@@ -442,7 +439,6 @@ export default function TestBuilder() {
                   }
                 />
                 <Input
-                  className="bg-slate-700 border-slate-600"
                   placeholder="Font weight (optional)"
                   value={formData.fontWeight}
                   onChange={(e) =>
@@ -450,7 +446,6 @@ export default function TestBuilder() {
                   }
                 />
                 <Input
-                  className="bg-slate-700 border-slate-600"
                   placeholder="Font size (optional)"
                   value={formData.fontSize}
                   onChange={(e) =>
@@ -459,7 +454,6 @@ export default function TestBuilder() {
                 />
                 {newElementTag === "a" && (
                   <Input
-                    className="bg-slate-700 border-slate-600"
                     placeholder="Link URL (href)"
                     value={formData.href}
                     onChange={(e) =>
@@ -504,7 +498,6 @@ export default function TestBuilder() {
                 )}
                 {formData.shouldClick && formData.checkNavigation && (
                   <Input
-                    className="bg-slate-700 border-slate-600"
                     placeholder="Navigation URL"
                     value={formData.navigationUrl}
                     onChange={(e) =>

--- a/frontend/components/TestCaseGenerator.tsx
+++ b/frontend/components/TestCaseGenerator.tsx
@@ -32,7 +32,7 @@ export default function TestCaseGenerator() {
         placeholder="Describe the scenario to test"
         value={scenario}
         onChange={(e) => setScenario(e.target.value)}
-        className="bg-slate-800 text-slate-100 border-slate-700"
+        className="bg-card text-foreground border-border"
         rows={5}
       />
       <Button
@@ -47,7 +47,7 @@ export default function TestCaseGenerator() {
         placeholder="Playwright test code will appear here"
         value={code}
         onChange={(e) => setCode(e.target.value)}
-        className="font-mono bg-slate-800 text-slate-100 border-slate-700 min-h-[200px]"
+        className="font-mono bg-card text-foreground border-border min-h-[200px]"
       />
     </div>
   );

--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Switch } from "@/components/ui/switch";
+
+export function ThemeToggle() {
+  const [isDark, setIsDark] = useState(true);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    const prefersDark =
+      stored === "dark" ||
+      (!stored && window.matchMedia("(prefers-color-scheme: dark)").matches);
+    document.documentElement.classList.toggle("dark", prefersDark);
+    setIsDark(prefersDark);
+  }, []);
+
+  function onToggle(checked: boolean) {
+    document.documentElement.classList.toggle("dark", checked);
+    localStorage.setItem("theme", checked ? "dark" : "light");
+    setIsDark(checked);
+  }
+
+  return (
+    <div className="ml-auto flex items-center">
+      <Switch checked={isDark} onCheckedChange={onToggle} />
+    </div>
+  );
+}

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -12,13 +12,13 @@ const buttonVariants = cva(
         default:
           'bg-primary text-primary-foreground shadow hover:bg-primary/90',
         builder:
-          'bg-indigo-600 text-white shadow hover:bg-indigo-700 focus-visible:ring-indigo-500',
+          'bg-primary text-primary-foreground shadow hover:bg-primary/90',
         destructive:
           'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
         outline:
           'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
         secondary:
-          'bg-slate-700 text-slate-100 shadow-sm hover:bg-slate-600',
+          'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline'
       },


### PR DESCRIPTION
## Summary
- replace hard-coded dark colors in Test Builder with theme-aware variables
- make TestCaseGenerator and custom button variants respect light/dark theme

## Testing
- `npm test --workspace frontend` (fails: Missing script "test")
- `npm run lint --workspace frontend` (fails: next not found)


------
https://chatgpt.com/codex/tasks/task_e_68a3a4dd26ec833284f4d369bb53331e